### PR TITLE
meta-three: add example layer with custom machine

### DIFF
--- a/meta-three/conf/distro/exampledistro.conf
+++ b/meta-three/conf/distro/exampledistro.conf
@@ -1,0 +1,9 @@
+DISTROOVERRIDES =. "poky:"
+require conf/distro/poky.conf
+# fslc-base.inc reverses the order of the layers so we can't prepend
+
+DISTRO = "example"
+DISTRO_NAME = "Example distro"
+DISTRO_VERSION = "1.0"
+
+DISTRO_FEATURES += "wayland pam"

--- a/meta-three/conf/layer.conf
+++ b/meta-three/conf/layer.conf
@@ -1,0 +1,14 @@
+BBPATH .= ":${LAYERDIR}"
+BBFILES += "\
+    ${LAYERDIR}/recipes-*/*/*.bb \
+    ${LAYERDIR}/recipes-*/*/*.bbappend \
+"
+
+BBFILE_COLLECTIONS += "three"
+BBFILE_PATTERN_three = "^${LAYERDIR}/"
+BBFILE_PRIORITY_three = "5"
+LAYERVERSION_three = "1"
+# Should suggest layer names on typing
+LAYERDEPENDS_three = "one"
+
+LAYERSERIES_COMPAT_three = "bitbakeexample"

--- a/meta-three/conf/machine/examplemachine.conf
+++ b/meta-three/conf/machine/examplemachine.conf
@@ -1,0 +1,4 @@
+MACHINEOVERRIDES =. "qemux86-64:"
+require conf/machine/qemux86-64.conf
+
+MACHINE_FEATURES += "bluetooth"

--- a/meta-three/conf/recipes-core/systemd/systemd-conf/examplemachine/wlan0.network
+++ b/meta-three/conf/recipes-core/systemd/systemd-conf/examplemachine/wlan0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=wlan0
+
+[Network]
+DHCP=ipv4

--- a/meta-three/conf/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-three/conf/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:examplemachine = " \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://wlan0.network', '', d)} \
+"
+
+do_install:append:examplemachine() {
+    install -d ${D}${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/wlan0.network ${D}${systemd_unitdir}/network
+    bbnote "Installed wlan0.network"
+}
+
+FILES:${PN}:append:examplemachine = "\
+    ${systemd_unitdir}/network/wlan0.network \
+"

--- a/meta-three/conf/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-three/conf/recipes-core/systemd/systemd-conf_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:examplemachine = " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'wifi', 'file://wlan0.network', '', d)} \
+    https://raw.githubusercontent.com/RobertCNelson/netifd/master/systemd/network/wlan0.network;destsuffix=systemd/network \
 "
 
 do_install:append:examplemachine() {


### PR DESCRIPTION
This layer is used to demonstrate common syntax related to machine and distro overrides.